### PR TITLE
Allow wider range of bpm in drummloop

### DIFF
--- a/src/drumloopplayer.cpp
+++ b/src/drumloopplayer.cpp
@@ -44,6 +44,7 @@ DrumLoopPlayer::DrumLoopPlayer(const double &volume, QObject *parent) :
     qDebug() << "SoundTouch library version" << SoundTouch::getVersionString();
 #endif
     connect(m_watcher, SIGNAL(finished()), this, SLOT(processFinished()));
+    qDebug() << "SoundTouch not available!";
 }
 
 DrumLoopPlayer::~DrumLoopPlayer()
@@ -75,12 +76,12 @@ int DrumLoopPlayer::originalBpm() const
 
 int DrumLoopPlayer::minBpm() const
 {
-    return m_measuredBpm - 11;
+    return m_measuredBpm - 30;
 }
 
 int DrumLoopPlayer::maxBpm() const
 {
-    return m_measuredBpm + 9;
+    return m_measuredBpm + 30;
 }
 
 void DrumLoopPlayer::stop()

--- a/src/drumloopplayer.cpp
+++ b/src/drumloopplayer.cpp
@@ -76,19 +76,12 @@ int DrumLoopPlayer::originalBpm() const
 
 int DrumLoopPlayer::minBpm() const
 {
-    if (m_measuredBpm > 30)
-    {
-        return m_measuredBpm - 30;
-    }
-    else
-    {
-        return 1;
-    }
+	return 0.8*m_measuredBpm;
 }
 
 int DrumLoopPlayer::maxBpm() const
 {
-    return m_measuredBpm + 30;
+    return 1.2*m_measuredBpm;
 }
 
 void DrumLoopPlayer::stop()

--- a/src/drumloopplayer.cpp
+++ b/src/drumloopplayer.cpp
@@ -76,7 +76,14 @@ int DrumLoopPlayer::originalBpm() const
 
 int DrumLoopPlayer::minBpm() const
 {
-    return m_measuredBpm - 30;
+    if (m_measuredBpm > 30)
+    {
+        return m_measuredBpm - 30;
+    }
+    else
+    {
+        return 1;
+    }
 }
 
 int DrumLoopPlayer::maxBpm() const


### PR DESCRIPTION
- [x] allow -30 to +30 bpm compared to default bpm
- [x] make sure, that values can't become negative