### PR TITLE
Migrate to Ubuntu Touch 20.04

### DIFF
--- a/apps/ubuntu/guitar-tools.apparmor
+++ b/apps/ubuntu/guitar-tools.apparmor
@@ -4,5 +4,5 @@
         "audio",
         "microphone"
     ],
-    "policy_version": 16.04
+    "policy_version": 20.04
 }

--- a/apps/ubuntu/guitar-tools.desktop
+++ b/apps/ubuntu/guitar-tools.desktop
@@ -4,5 +4,5 @@ Exec=guitar-tools
 Icon=guitar-tools/guitar-tools.png
 Terminal=false
 Type=Application
-X-Ubuntu-Touch=true
-X-Ubuntu-Supported-Orientations=portrait
+X-Lomiri-Touch=true
+X-Lomiri-Supported-Orientations=portrait

--- a/apps/ubuntu/manifest.json.in
+++ b/apps/ubuntu/manifest.json.in
@@ -11,5 +11,5 @@
     },
     "version": "0.5.4",
     "maintainer": "Simon Stürz <stuerz.simon@gmail.com>",
-    "framework": "ubuntu-sdk-16.04"
+    "framework": "@CLICK_FRAMEWORK@"
 }

--- a/apps/ubuntu/qml/AboutPage.qml
+++ b/apps/ubuntu/qml/AboutPage.qml
@@ -20,9 +20,9 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 
 Page {
@@ -66,7 +66,7 @@ Page {
                 }
 
 
-                UbuntuShape {
+                LomiriShape {
                     id: iconImage
                     anchors.horizontalCenter: parent.horizontalCenter
                     width: units.gu(10)

--- a/apps/ubuntu/qml/ChordPage.qml
+++ b/apps/ubuntu/qml/ChordPage.qml
@@ -21,8 +21,8 @@
 import QtQuick 2.4
 import QtMultimedia 5.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.0
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.0
 import GuitarTools 1.0
 import "components"
 
@@ -280,14 +280,14 @@ Page {
                             height: width
                             radius: width / 2
                             border.width: radius / 4
-                            border.color: chord.positions.get(index).fret < 0 ? UbuntuColors.red : UbuntuColors.green
+                            border.color: chord.positions.get(index).fret < 0 ? LomiriColors.red : LomiriColors.green
                             color: theme.palette.normal.base
 
                             ColorAnimation {
                                 id: pluckAnimation
                                 target: indicator
                                 property: "color"
-                                from: UbuntuColors.green
+                                from: LomiriColors.green
                                 to: theme.palette.normal.base
                                 easing.type: Easing.InQuad
                                 duration: 1000
@@ -320,7 +320,7 @@ Page {
                     width: barreItem.length
                     height: fingerboardImage.fingerSize
                     radius: height / 2
-                    color: UbuntuColors.blue
+                    color: LomiriColors.blue
 
                     Label {
                         anchors.centerIn: parent
@@ -355,7 +355,7 @@ Page {
                         width: parent.width * 0.8
                         height: width
                         radius: width / 2
-                        color: UbuntuColors.green
+                        color: LomiriColors.green
 
                         Label {
                             anchors.centerIn: parent

--- a/apps/ubuntu/qml/ChordsHelpPage.qml
+++ b/apps/ubuntu/qml/ChordsHelpPage.qml
@@ -20,9 +20,9 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 
 Page {
@@ -76,7 +76,7 @@ Page {
                     height: width
                     radius: width / 2
                     border.width: radius / 4
-                    border.color: UbuntuColors.red
+                    border.color: LomiriColors.red
                     color: theme.palette.normal.base
                 }
 
@@ -99,7 +99,7 @@ Page {
                     height: width
                     radius: width / 2
                     border.width: radius / 4
-                    border.color: UbuntuColors.green
+                    border.color: LomiriColors.green
                     color: theme.palette.normal.base
                 }
 

--- a/apps/ubuntu/qml/ComposeLoadPage.qml
+++ b/apps/ubuntu/qml/ComposeLoadPage.qml
@@ -20,9 +20,9 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 import "components"
 

--- a/apps/ubuntu/qml/ComposePage.qml
+++ b/apps/ubuntu/qml/ComposePage.qml
@@ -20,9 +20,9 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 import "components"
 
@@ -310,7 +310,7 @@ Page {
                                 }
                             }
 
-                            delegate: UbuntuShape {
+                            delegate: LomiriShape {
                                 id: noteShape
                                 width: gridView.cellWidth
                                 height: gridView.cellHeight
@@ -332,7 +332,7 @@ Page {
                                     return true
                                 }
 
-                                UbuntuShape {
+                                LomiriShape {
                                     id: innerNoteRectangle
                                     anchors.fill: parent
                                     anchors.margins: units.gu(0.8)
@@ -379,9 +379,9 @@ Page {
                                 Behavior on x { NumberAnimation { duration: 250; easing.type: Easing.OutBack } }
                                 Behavior on y { NumberAnimation { duration: 250; easing.type: Easing.OutBack } }
 
-                                UbuntuShape {
+                                LomiriShape {
                                     id: removeShape
-                                    color: UbuntuColors.lightGrey
+                                    color: LomiriColors.lightGrey
                                     anchors.left: noteShape.left
                                     anchors.top: noteShape.top
                                     width: removeRectangleWidth
@@ -495,16 +495,16 @@ Page {
                                 height: gridCellHeight
                             }
 
-                            UbuntuShape {
+                            LomiriShape {
                                 id: movingNoteShape
                                 width: gridView.cellWidth
                                 height: gridView.cellHeight
                                 z: 2
                                 radius: "large"
-                                color: UbuntuColors.blue
+                                color: LomiriColors.blue
                                 visible: false
 
-                                UbuntuShape {
+                                LomiriShape {
                                     id: movingiInnerNoteRectangle
                                     anchors.fill: parent
                                     anchors.margins: units.gu(0.8)
@@ -678,7 +678,7 @@ Page {
                             id: playMark
                             height: backgroundHeight
                             width: units.gu(0.3)
-                            color: UbuntuColors.red
+                            color: LomiriColors.red
                             y: 0
                             x: backgroundShape.width * Core.composeTool.positionPercentage - width / 2
                             z: 20
@@ -750,7 +750,7 @@ Page {
                 id: settingsButton
                 Layout.fillWidth: true
                 iconName: "camera-self-timer"
-                color: Core.composeTool.enableMetronome ? UbuntuColors.green : theme.palette.normal.base
+                color: Core.composeTool.enableMetronome ? LomiriColors.green : theme.palette.normal.base
                 onClicked: {
                     Core.composeTool.enableMetronome = !Core.composeTool.enableMetronome
                     Core.composeTool.save()
@@ -889,7 +889,7 @@ Page {
             Button {
                 // TRANSLATORS: Create new song button
                 text: i18n.tr("Create")
-                color: UbuntuColors.green
+                color: LomiriColors.green
                 onClicked: {
                     Core.composeTool.newSong(songNameTextField.text);
                     PopupUtils.close(newSongDialog)
@@ -922,7 +922,7 @@ Page {
             Button {
                 // TRANSLATORS: Save button in the 'Save as' dialog
                 text: i18n.tr("Save")
-                color: UbuntuColors.green
+                color: LomiriColors.green
                 onClicked: {
                     Core.composeTool.saveAs(songNameTextField.text);
                     PopupUtils.close(saveAsDialog)
@@ -943,7 +943,7 @@ Page {
 
             // TRANSLATORS: Title of the load song as dialog
             title: i18n.tr("Load song")
-            UbuntuListView {
+            LomiriListView {
                 id: songsListView
                 clip: true
                 model: Core.composeTool.songs
@@ -987,7 +987,7 @@ Page {
             Button {
                 // TRANSLATORS: Save button in the 'Save as' dialog
                 text: i18n.tr("Rename")
-                color: UbuntuColors.green
+                color: LomiriColors.green
                 onClicked: {
                     Core.composeTool.renameSong(songNameTextField.text);
                     PopupUtils.close(renameDialog)
@@ -1016,7 +1016,7 @@ Page {
             Button {
                 id: deleteButton
                 text: i18n.tr("Delete")
-                color: UbuntuColors.red
+                color: LomiriColors.red
                 onClicked: {
                     PopupUtils.close(removeDialog)
                     Core.composeTool.deleteSong(Core.composeTool.songName)
@@ -1027,7 +1027,7 @@ Page {
 
             Button {
                 text: i18n.tr("Cancel")
-                color: UbuntuColors.green
+                color: LomiriColors.green
                 onClicked: PopupUtils.close(removeDialog)
             }
         }

--- a/apps/ubuntu/qml/ComposeSelectorPage.qml
+++ b/apps/ubuntu/qml/ComposeSelectorPage.qml
@@ -20,9 +20,9 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.ListItems 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.ListItems 1.3
+import Lomiri.Components.Pickers 1.3
 import "components"
 import GuitarTools 1.0
 
@@ -53,7 +53,7 @@ Page {
                 anchors.margins: units.gu(1)
                 // TRANSLATORS: Button in the note selection page of the compose tool (play mode -> click on note plays note, select mode -> click on note selects note)
                 text: scale.selectMode ? i18n.tr("Play mode") : i18n.tr("Select mode")
-                color: scale.selectMode ? UbuntuColors.green : UbuntuColors.graphite
+                color: scale.selectMode ? LomiriColors.green : LomiriColors.graphite
                 Behavior on color { ColorAnimation { duration: 400 ; easing.type: scale.selectMode ? Easing.OutQuad : Easing.InQuad} }
                 onClicked: scale.selectMode = !scale.selectMode
             }

--- a/apps/ubuntu/qml/ComposeSettingsPage.qml
+++ b/apps/ubuntu/qml/ComposeSettingsPage.qml
@@ -20,10 +20,10 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
+import Lomiri.Components.Pickers 1.3
 import GuitarTools 1.0
 
 Page {
@@ -257,7 +257,7 @@ Page {
                 // TRANSLATORS: Removes all notes in the compose tool
                 text: i18n.tr("Clear all notes")
                 Layout.fillWidth: true
-                color: UbuntuColors.red
+                color: LomiriColors.red
                 onClicked: PopupUtils.open(clearNotesComponent)
             }
         }
@@ -276,7 +276,7 @@ Page {
                 Button {
                     id: deleteButton
                     text: i18n.tr("Clear")
-                    color: UbuntuColors.red
+                    color: LomiriColors.red
                     onClicked: {
                         PopupUtils.close(clearNotesDialog)
                         Core.composeTool.clearNotes()
@@ -287,7 +287,7 @@ Page {
 
                 Button {
                     text: i18n.tr("Cancel")
-                    color: UbuntuColors.green
+                    color: LomiriColors.green
                     onClicked: PopupUtils.close(clearNotesDialog)
                 }
 

--- a/apps/ubuntu/qml/DrumLoopPage.qml
+++ b/apps/ubuntu/qml/DrumLoopPage.qml
@@ -21,8 +21,8 @@
 import QtQuick 2.4
 import QtMultimedia 5.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.ListItems 1.3
 import Qt.labs.folderlistmodel 1.0
 import GuitarTools 1.0
 

--- a/apps/ubuntu/qml/FretBoardPage.qml
+++ b/apps/ubuntu/qml/FretBoardPage.qml
@@ -21,8 +21,8 @@
 import QtQuick 2.4
 import QtMultimedia 5.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.0
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.0
 import GuitarTools 1.0
 import "components"
 

--- a/apps/ubuntu/qml/GuitarPlayerPage.qml
+++ b/apps/ubuntu/qml/GuitarPlayerPage.qml
@@ -21,10 +21,10 @@
 import QtQuick 2.4
 import QtMultimedia 5.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
+import Lomiri.Components.Pickers 1.3
 import GuitarTools 1.0
 import "components"
 
@@ -84,12 +84,12 @@ Page {
 
                 property string chordName
 
-                UbuntuShape {
+                LomiriShape {
                     id: temporaryShape
                     anchors.fill: dragItem
                     anchors.margins: units.gu(1)
                     z: 1
-                    color: UbuntuColors.green
+                    color: LomiriColors.green
 
                     Label {
                         anchors.centerIn: parent
@@ -542,14 +542,14 @@ Page {
                             height: width
                             radius: width / 2
                             border.width: radius / 4
-                            border.color: chord.positions.get(index).fret < 0 ? UbuntuColors.red : UbuntuColors.green
+                            border.color: chord.positions.get(index).fret < 0 ? LomiriColors.red : LomiriColors.green
                             color: theme.palette.normal.base
 
                             ColorAnimation {
                                 id: pluckAnimation
                                 target: indicator
                                 property: "color"
-                                from: UbuntuColors.green
+                                from: LomiriColors.green
                                 to: theme.palette.normal.base
                                 easing.type: Easing.InQuad
                                 duration: 1000
@@ -562,7 +562,7 @@ Page {
             Button  {
                 // TRANSLATORS: Play button in the chord selection popover (guitar)
                 text: i18n.tr("Play")
-                color: UbuntuColors.blue
+                color: LomiriColors.blue
                 onClicked: {
                     console.log("Listen chord: " +  app.noteToString(chordPlayer.chord.note) + chordPlayer.chord.name)
                     chordPlayer.playChord()
@@ -574,7 +574,7 @@ Page {
             Button  {
                 // TRANSLATORS: Add button in the chord selection popover (guitar)
                 text: i18n.tr("Add")
-                color: UbuntuColors.green
+                color: LomiriColors.green
                 onClicked: {
                     console.log("Add chord: " +  app.noteToString(chordSelectionDialog.chord.note) + chordSelectionDialog.chord.name)
                     Core.guitarPlayerChords.addChord(chordSelectionDialog.chord)

--- a/apps/ubuntu/qml/GuitarTunerPage.qml
+++ b/apps/ubuntu/qml/GuitarTunerPage.qml
@@ -19,7 +19,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 import QtQuick.Layouts 1.1
 import GuitarTools 1.0
 import "components"
@@ -77,7 +77,7 @@ Page {
             font.bold: true
             font.pixelSize: units.gu(8)
             text: note
-            color: value >= -tolerance && value <= tolerance ? UbuntuColors.green : theme.palette.normal.baseText
+            color: value >= -tolerance && value <= tolerance ? LomiriColors.green : theme.palette.normal.baseText
         }
 
         Label {

--- a/apps/ubuntu/qml/Main.qml
+++ b/apps/ubuntu/qml/Main.qml
@@ -19,7 +19,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 import QtSystemInfo 5.0
 import GuitarTools 1.0
 
@@ -35,7 +35,7 @@ MainView {
 
     Component.onCompleted: {
         i18n.domain = "guitar-tools.t-mon"
-        Theme.name = Core.settings.darkThemeEnabled ? "Ubuntu.Components.Themes.SuruDark" : "Ubuntu.Components.Themes.Ambiance"
+        Theme.name = Core.settings.darkThemeEnabled ? "Lomiri.Components.Themes.SuruDark" : "Lomiri.Components.Themes.Ambiance"
     }
 
     ScreenSaver {
@@ -56,7 +56,7 @@ MainView {
 
     Connections {
         target: Core.settings
-        onDarkThemeEnabledChanged: Core.settings.darkThemeEnabled ? Theme.name = "Ubuntu.Components.Themes.SuruDark" : Theme.name = "Ubuntu.Components.Themes.Ambiance"
+        onDarkThemeEnabledChanged: Core.settings.darkThemeEnabled ? Theme.name = "Lomiri.Components.Themes.SuruDark" : Theme.name = "Lomiri.Components.Themes.Ambiance"
     }
 
     AdaptivePageLayout {

--- a/apps/ubuntu/qml/MainPage.qml
+++ b/apps/ubuntu/qml/MainPage.qml
@@ -20,9 +20,9 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 import "components"
 

--- a/apps/ubuntu/qml/MetronomePage.qml
+++ b/apps/ubuntu/qml/MetronomePage.qml
@@ -21,8 +21,8 @@
 import QtQuick 2.4
 import QtMultimedia 5.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 import "components"
 

--- a/apps/ubuntu/qml/RecorderPage.qml
+++ b/apps/ubuntu/qml/RecorderPage.qml
@@ -21,7 +21,7 @@
 import QtQuick 2.4
 import QtMultimedia 5.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 import Qt.labs.folderlistmodel 1.0
 import GuitarTools 1.0
 import "components"
@@ -105,7 +105,7 @@ Page {
             Behavior on opacity { NumberAnimation { duration: 500 } }
         }
 
-        UbuntuShape {
+        LomiriShape {
             id: recordButton
             anchors.horizontalCenter: parent.horizontalCenter
             width: units.gu(15)

--- a/apps/ubuntu/qml/RecorderPlaylistHelpPage.qml
+++ b/apps/ubuntu/qml/RecorderPlaylistHelpPage.qml
@@ -20,9 +20,9 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 
 Page {

--- a/apps/ubuntu/qml/RecorderPlaylistPage.qml
+++ b/apps/ubuntu/qml/RecorderPlaylistPage.qml
@@ -22,9 +22,9 @@ import QtQuick 2.4
 import QtMultimedia 5.4
 import Qt.labs.folderlistmodel 1.0
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 
 Page {
@@ -161,7 +161,7 @@ Page {
             Button {
                 // TRANSLATORS: Delete button in the remove record dialog
                 text: i18n.tr("Delete")
-                color: UbuntuColors.red
+                color: LomiriColors.red
                 onClicked: {
                     Core.recorder.deleteRecordFile(root.fileNamePath);
                     PopupUtils.close(removeDialog)
@@ -195,7 +195,7 @@ Page {
             Button {
                 // TRANSLATORS: Rename button in the rename record dialog
                 text: i18n.tr("Rename")
-                color: UbuntuColors.green
+                color: LomiriColors.green
                 onClicked: {
                     Core.recorder.renameRecordFile(root.fileNamePath, fileNameTextField.text);
                     PopupUtils.close(renameDialog)

--- a/apps/ubuntu/qml/ScalesPage.qml
+++ b/apps/ubuntu/qml/ScalesPage.qml
@@ -21,8 +21,8 @@
 import QtQuick 2.4
 import QtMultimedia 5.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.0
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.0
 import GuitarTools 1.0
 import "components"
 

--- a/apps/ubuntu/qml/SettingsPage.qml
+++ b/apps/ubuntu/qml/SettingsPage.qml
@@ -21,10 +21,10 @@
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import QtGraphicalEffects 1.0
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.Pickers 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.Pickers 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 
 Page {
@@ -490,7 +490,7 @@ Page {
                 Layout.fillWidth: true
                 Layout.preferredHeight: units.gu(5)
 
-                UbuntuShape {
+                LomiriShape {
                     id: color1Shape
                     height: parent.height
                     width: height
@@ -503,7 +503,7 @@ Page {
                     }
                 }
 
-                UbuntuShape {
+                LomiriShape {
                     id: color2Shape
                     height: parent.height
                     width: height
@@ -515,7 +515,7 @@ Page {
                     }
                 }
 
-                UbuntuShape {
+                LomiriShape {
                     id: color3Shape
                     height: parent.height
                     width: height

--- a/apps/ubuntu/qml/TuningForkPage.qml
+++ b/apps/ubuntu/qml/TuningForkPage.qml
@@ -20,9 +20,9 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 
 Page {

--- a/apps/ubuntu/qml/components/ChordsBottomEdge.qml
+++ b/apps/ubuntu/qml/components/ChordsBottomEdge.qml
@@ -20,8 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.3
 import QtQuick.Layouts 1.1
 import GuitarTools 1.0
 
@@ -108,7 +108,7 @@ Item {
 
             height: contentColumn.height + units.gu(4)
             Behavior on anchors.topMargin {
-                UbuntuNumberAnimation {}
+                LomiriNumberAnimation {}
             }
 
             color: theme.palette.normal.overlay
@@ -118,12 +118,12 @@ Item {
                 anchors { left: contentRect.left; top: contentRect.top; right: contentRect.right }
                 height: units.gu(2)
 
-                UbuntuShape {
+                LomiriShape {
                     anchors.centerIn: parent
                     height: units.gu(1)
                     width: units.gu(5)
                     radius: "medium"
-                    color: UbuntuColors.inkstone
+                    color: LomiriColors.inkstone
                 }
 
                 color: theme.palette.normal.overlaySecondaryText

--- a/apps/ubuntu/qml/components/ComposeBottomEdge.qml
+++ b/apps/ubuntu/qml/components/ComposeBottomEdge.qml
@@ -20,8 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.3
 import QtQuick.Layouts 1.1
 import GuitarTools 1.0
 
@@ -110,7 +110,7 @@ Item {
             height: contentColumn.height + units.gu(4)
 
             Behavior on anchors.topMargin {
-                UbuntuNumberAnimation {}
+                LomiriNumberAnimation {}
             }
 
             color: theme.palette.normal.overlay
@@ -120,12 +120,12 @@ Item {
                 anchors { left: contentRect.left; top: contentRect.top; right: contentRect.right }
                 height: units.gu(2)
 
-                UbuntuShape {
+                LomiriShape {
                     anchors.centerIn: parent
                     height: units.gu(1)
                     width: units.gu(5)
                     radius: "medium"
-                    color: UbuntuColors.inkstone
+                    color: LomiriColors.inkstone
                 }
 
                 color: theme.palette.normal.overlaySecondaryText

--- a/apps/ubuntu/qml/components/FretBoardBottomEdge.qml
+++ b/apps/ubuntu/qml/components/FretBoardBottomEdge.qml
@@ -20,8 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.3
 import QtQuick.Layouts 1.1
 import GuitarTools 1.0
 
@@ -108,7 +108,7 @@ Item {
 
             height: contentColumn.height + units.gu(4)
             Behavior on anchors.topMargin {
-                UbuntuNumberAnimation {}
+                LomiriNumberAnimation {}
             }
 
             color: theme.palette.normal.overlay
@@ -118,12 +118,12 @@ Item {
                 anchors { left: contentRect.left; top: contentRect.top; right: contentRect.right }
                 height: units.gu(2)
 
-                UbuntuShape {
+                LomiriShape {
                     anchors.centerIn: parent
                     height: units.gu(1)
                     width: units.gu(5)
                     radius: "medium"
-                    color: UbuntuColors.inkstone
+                    color: LomiriColors.inkstone
                 }
 
                 color: theme.palette.normal.overlaySecondaryText

--- a/apps/ubuntu/qml/components/GuitarBottomEdge.qml
+++ b/apps/ubuntu/qml/components/GuitarBottomEdge.qml
@@ -20,8 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.3
 import QtQuick.Layouts 1.1
 import GuitarTools 1.0
 
@@ -109,7 +109,7 @@ Item {
 
             height: contentColumn.height + units.gu(4)
             Behavior on anchors.topMargin {
-                UbuntuNumberAnimation {}
+                LomiriNumberAnimation {}
             }
 
             color: theme.palette.normal.overlay
@@ -119,12 +119,12 @@ Item {
                 anchors { left: contentRect.left; top: contentRect.top; right: contentRect.right }
                 height: units.gu(2)
 
-                UbuntuShape {
+                LomiriShape {
                     anchors.centerIn: parent
                     height: units.gu(1)
                     width: units.gu(5)
                     radius: "medium"
-                    color: UbuntuColors.inkstone
+                    color: LomiriColors.inkstone
                 }
 
                 color: theme.palette.normal.overlaySecondaryText

--- a/apps/ubuntu/qml/components/GuitarChordItem.qml
+++ b/apps/ubuntu/qml/components/GuitarChordItem.qml
@@ -19,7 +19,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 import GuitarTools 1.0
 
 Item {
@@ -29,13 +29,13 @@ Item {
 
     property var chord: Core.guitarPlayerChords.get(index)
 
-    UbuntuShape {
+    LomiriShape {
         id: chrodShape
         anchors.fill: chordItem
         anchors.margins: units.gu(1)
         x: chordItem.x
         y: chordItem.y
-        color: index === root.selectedIndex ? UbuntuColors.green : theme.palette.normal.base
+        color: index === root.selectedIndex ? LomiriColors.green : theme.palette.normal.base
 
         Label {
             anchors.centerIn: parent
@@ -106,9 +106,9 @@ Item {
         }
     }
 
-    UbuntuShape {
+    LomiriShape {
         id: removeShape
-        color: UbuntuColors.lightGrey
+        color: LomiriColors.lightGrey
         anchors.left: chordItem.left
         anchors.top: chordItem.top
         width: chordsGridMouseArea.removeAreaWidth

--- a/apps/ubuntu/qml/components/GuitarStringItem.qml
+++ b/apps/ubuntu/qml/components/GuitarStringItem.qml
@@ -21,9 +21,9 @@
 import QtQuick 2.4
 import QtMultimedia 5.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 
 Item {
@@ -63,7 +63,7 @@ Item {
         height: thickness
         color: {
             if (fret < 0 && Core.settings.markNotAssociatedStrings) {
-                return UbuntuColors.red
+                return LomiriColors.red
             } else {
                 return theme.palette.normal.baseText
             }

--- a/apps/ubuntu/qml/components/MainMenuListItem.qml
+++ b/apps/ubuntu/qml/components/MainMenuListItem.qml
@@ -19,7 +19,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 import GuitarTools 1.0
 
 ListItem {

--- a/apps/ubuntu/qml/components/MetronomeBottomEdge.qml
+++ b/apps/ubuntu/qml/components/MetronomeBottomEdge.qml
@@ -20,8 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.3
 import QtQuick.Layouts 1.1
 import GuitarTools 1.0
 
@@ -109,7 +109,7 @@ Item {
             height: contentColumn.height + units.gu(4)
 
             Behavior on anchors.topMargin {
-                UbuntuNumberAnimation {}
+                LomiriNumberAnimation {}
             }
 
             color: theme.palette.normal.overlay
@@ -119,12 +119,12 @@ Item {
                 anchors { left: contentRect.left; top: contentRect.top; right: contentRect.right }
                 height: units.gu(2)
 
-                UbuntuShape {
+                LomiriShape {
                     anchors.centerIn: parent
                     height: units.gu(1)
                     width: units.gu(5)
                     radius: "medium"
-                    color: UbuntuColors.inkstone
+                    color: LomiriColors.inkstone
                 }
 
                 color: theme.palette.normal.overlaySecondaryText

--- a/apps/ubuntu/qml/components/MicrophoneVolumeBottomEdge.qml
+++ b/apps/ubuntu/qml/components/MicrophoneVolumeBottomEdge.qml
@@ -20,8 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.3
 import QtQuick.Layouts 1.1
 import GuitarTools 1.0
 
@@ -109,7 +109,7 @@ Item {
             height: contentColumn.height + units.gu(4)
 
             Behavior on anchors.topMargin {
-                UbuntuNumberAnimation {}
+                LomiriNumberAnimation {}
             }
 
             color: theme.palette.normal.overlay
@@ -119,12 +119,12 @@ Item {
                 anchors { left: contentRect.left; top: contentRect.top; right: contentRect.right }
                 height: units.gu(2)
 
-                UbuntuShape {
+                LomiriShape {
                     anchors.centerIn: parent
                     height: units.gu(1)
                     width: units.gu(5)
                     radius: "medium"
-                    color: UbuntuColors.inkstone
+                    color: LomiriColors.inkstone
                 }
 
                 color: theme.palette.normal.overlaySecondaryText

--- a/apps/ubuntu/qml/components/ScaleItem.qml
+++ b/apps/ubuntu/qml/components/ScaleItem.qml
@@ -21,9 +21,9 @@
 import QtQuick 2.4
 import QtMultimedia 5.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Components.ListItems 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Popups 1.3
+import Lomiri.Components.ListItems 1.3
 import GuitarTools 1.0
 
 Item {
@@ -90,9 +90,9 @@ Item {
                             border.width: radius / 4
                             border.color: {
                                 if (!colorfull && !root.selectMode && fretPositionItem.note === root.scale.note) {
-                                    return UbuntuColors.blue
+                                    return LomiriColors.blue
                                 } else if (!colorfull && !root.selectMode) {
-                                    return UbuntuColors.green
+                                    return LomiriColors.green
                                 } else if (colorfull && !root.selectMode) {
                                     return Core.getColorForNote(fretPositionItem.fretPosition.noteFileName)
                                 } else {
@@ -123,7 +123,7 @@ Item {
 
                             MouseArea {
                                 anchors.fill: parent
-                                onPressed: if (selectMode) positionRectangle.border.color = UbuntuColors.blue
+                                onPressed: if (selectMode) positionRectangle.border.color = LomiriColors.blue
                                 onReleased: if (selectMode) positionRectangle.border.color = theme.palette.normal.base
                                 onClicked: {
                                     if (selectMode) {

--- a/apps/ubuntu/qml/components/ScalesBottomEdge.qml
+++ b/apps/ubuntu/qml/components/ScalesBottomEdge.qml
@@ -20,8 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.3
 import QtQuick.Layouts 1.1
 import GuitarTools 1.0
 
@@ -109,7 +109,7 @@ Item {
 
             height: contentColumn.height + units.gu(4)
             Behavior on anchors.topMargin {
-                UbuntuNumberAnimation {}
+                LomiriNumberAnimation {}
             }
 
             color: theme.palette.normal.overlay
@@ -119,12 +119,12 @@ Item {
                 anchors { left: contentRect.left; top: contentRect.top; right: contentRect.right }
                 height: units.gu(2)
 
-                UbuntuShape {
+                LomiriShape {
                     anchors.centerIn: parent
                     height: units.gu(1)
                     width: units.gu(5)
                     radius: "medium"
-                    color: UbuntuColors.inkstone
+                    color: LomiriColors.inkstone
                 }
 
                 color: theme.palette.normal.overlaySecondaryText

--- a/apps/ubuntu/qml/components/TunerBottomEdge.qml
+++ b/apps/ubuntu/qml/components/TunerBottomEdge.qml
@@ -20,8 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 import QtQuick 2.4
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Pickers 1.3
+import Lomiri.Components 1.3
+import Lomiri.Components.Pickers 1.3
 import QtQuick.Layouts 1.1
 import GuitarTools 1.0
 
@@ -109,7 +109,7 @@ Item {
             height: contentColumn.height + units.gu(4)
 
             Behavior on anchors.topMargin {
-                UbuntuNumberAnimation {}
+                LomiriNumberAnimation {}
             }
 
             color: theme.palette.normal.overlay
@@ -119,12 +119,12 @@ Item {
                 anchors { left: contentRect.left; top: contentRect.top; right: contentRect.right }
                 height: units.gu(2)
 
-                UbuntuShape {
+                LomiriShape {
                     anchors.centerIn: parent
                     height: units.gu(1)
                     width: units.gu(5)
                     radius: "medium"
-                    color: UbuntuColors.inkstone
+                    color: LomiriColors.inkstone
                 }
 
                 color: theme.palette.normal.overlaySecondaryText

--- a/clickable.json
+++ b/clickable.json
@@ -1,6 +1,0 @@
-{
-  "clickable_minimum_required": "6.9.1",
-  "template": "qmake",
-  "build_args": "CONFIG+='ubuntu soundtouch'",
-  "dependencies_target": "libsoundtouch-dev"
-}

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,0 +1,5 @@
+clickable_minimum_required: 8.0.1
+
+builder: qmake
+build_args: CONFIG+='ubuntu soundtouch'
+dependencies_target: libsoundtouch-dev


### PR DESCRIPTION
This PR

- migrates the Ubuntu Touch build from 16.04 base to 20.04, including
  - apparmor policy
  - framework
  - QML renamings (from UUITK to Lomiri UITK)
- updates the Clickable version used to 8 (implies 20.04 framework)